### PR TITLE
Only intercept touch events for events inside the IndexScroller

### DIFF
--- a/src/com/woozzu/android/widget/IndexScroller.java
+++ b/src/com/woozzu/android/widget/IndexScroller.java
@@ -209,7 +209,7 @@ public class IndexScroller {
 		}
 	}
 	
-	private boolean contains(float x, float y) {
+	public boolean contains(float x, float y) {
 		// Determine if the point is in index bar region, which includes the right margin of the bar
 		return (x >= mIndexbarRect.left && y >= mIndexbarRect.top && y <= mIndexbarRect.top + mIndexbarRect.height());
 	}

--- a/src/com/woozzu/android/widget/IndexableListView.java
+++ b/src/com/woozzu/android/widget/IndexableListView.java
@@ -96,7 +96,10 @@ public class IndexableListView extends ListView {
 
 	@Override
 	public boolean onInterceptTouchEvent(MotionEvent ev) {
-		return true;
+		if(mScroller.contains(ev.getX(), ev.getY()))
+			return true;
+		
+		return super.onInterceptTouchEvent(ev);
 	}
 
 	@Override


### PR DESCRIPTION
This allows the ListView's children to receive touch events, while still intercepting them for touching the IndexScroller.