### PR TITLE
Odd behaviors fix

### DIFF
--- a/src/com/woozzu/android/widget/IndexableListView.java
+++ b/src/com/woozzu/android/widget/IndexableListView.java
@@ -95,11 +95,6 @@ public class IndexableListView extends ListView {
 	}
 
 	@Override
-	public boolean onInterceptTouchEvent(MotionEvent ev) {
-		return true;
-	}
-
-	@Override
 	public void setAdapter(ListAdapter adapter) {
 		super.setAdapter(adapter);
 		if (mScroller != null)


### PR DESCRIPTION
Removed `onInterceptTouchEvent` override on `IndexableListView` class. It was producing some odd behaviors:
- Touching on items wasn't firing the flashing visual feedback on majority of times;
- Wasn't doing the "elastic" effect when scrolling out the list (tested on Samsung phone);
- If `areAllItemsEnabled` and `isEnabled` methods were overridden on custom `CursorAdapter`, the disabled items were ignoring all touch events (this prevented scrolling when `fling` started on disabled items).

It should be at least:

```
@Override
public boolean onInterceptTouchEvent(MotionEvent ev) {
    return super.onInterceptTouchEvent(ev);
}
```

As it seems that this method isn't used for anything, I just dropped it.
